### PR TITLE
Update Docker image version in CI/CD pipelines to 1.0.48 and refactor…

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,22 +12,21 @@ jobs:
     name: Initialization of the repository
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    container:
+      image: chocotechnologies/swagger-codegen:1.0.48
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Initialize
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            chocotechnologies/swagger-codegen:1.0.46 \
-            ./initialize.sh
+        run: ./initialize.sh
 
   publish:
     name: Publishing of new version
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    container:
+      image: chocotechnologies/swagger-codegen:1.0.48
     permissions:
       contents: read
     steps:
@@ -36,14 +35,9 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - name: Generate and package clients
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          docker run --rm \
-            -v "${{ github.workspace }}:/workspace" \
-            -w /workspace \
-            -e VERSION="$VERSION" \
-            chocotechnologies/swagger-codegen:1.0.46 \
-            sh -c './publish.sh -v="$VERSION"'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: ./publish.sh -v="$VERSION"
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -7,26 +7,35 @@ on:
     tags:
       - 'v*'
 
+# NOTE: Intentionally using `docker run` instead of the native `container:` directive.
+# The `container:` approach runs ALL steps (including actions/checkout) inside the container,
+# which requires GLIBC >= 2.28. The swagger-codegen image is based on an older OS that does
+# not meet this requirement, causing Node.js (used by GitHub Actions internals) to fail with:
+#   "version `GLIBC_2.28' not found"
+# With `docker run`, only the actual script runs inside the container while GitHub Actions
+# internals (checkout etc.) execute on the host runner which has a sufficiently new GLIBC.
+
 jobs:
   initialize:
     name: Initialization of the repository
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-    container:
-      image: chocotechnologies/swagger-codegen:1.0.48
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Initialize
-        run: ./initialize.sh
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            chocotechnologies/swagger-codegen:1.0.48 \
+            ./initialize.sh
 
   publish:
     name: Publishing of new version
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    container:
-      image: chocotechnologies/swagger-codegen:1.0.48
     permissions:
       contents: read
     steps:
@@ -35,9 +44,14 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
       - name: Generate and package clients
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: ./publish.sh -v="$VERSION"
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            -e VERSION="$VERSION" \
+            chocotechnologies/swagger-codegen:1.0.48 \
+            sh -c './publish.sh -v="$VERSION"'
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ artifacts/
 
 ## CI/CD (Bitbucket Pipelines)
 
-The pipeline is defined in `bitbucket-pipelines.yml` and runs on the `chocotechnologies/swagger-codegen:1.0.46` Docker image.
+The pipeline is defined in `bitbucket-pipelines.yml` and runs on the `chocotechnologies/swagger-codegen:1.0.48` Docker image.
 
 | Trigger | Step | Script |
 |---|---|---|

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -2,7 +2,7 @@ pipelines:
     default:
         - step:
             name: "Initialization of the repository"
-            image: simplinion/swagger-codegen:1.0.46
+            image: simplinion/swagger-codegen:1.0.48
             trigger: automatic
             script:
                 - ./initialize.sh
@@ -10,7 +10,7 @@ pipelines:
         V.*:
             - step:
                 name: Publishing of new version
-                image: simplinion/swagger-codegen:1.0.46
+                image: simplinion/swagger-codegen:1.0.48
                 trigger: automatic
                 script:
                     - ./publish.sh -v="${BITBUCKET_TAG/V./}"


### PR DESCRIPTION
This pull request updates the CI/CD pipeline configurations to use a newer version (`1.0.48`) of the `swagger-codegen` Docker image across both GitHub Actions and Bitbucket Pipelines. The changes also simplify the GitHub Actions workflow by removing direct `docker run` commands and leveraging the `container` field for job execution.

**CI/CD Pipeline Updates:**

* Updated the Docker image in GitHub Actions (`.github/workflows/pipeline.yml`) for both initialization and publishing jobs from `chocotechnologies/swagger-codegen:1.0.46` to `1.0.48`, and refactored the jobs to use the `container` field instead of explicit `docker run` commands. [[1]](diffhunk://#diff-fe700949ba86403864aa7b6fdcab2c00c55e1047f73a6a282135a35e8a21e03bR15-R29) [[2]](diffhunk://#diff-fe700949ba86403864aa7b6fdcab2c00c55e1047f73a6a282135a35e8a21e03bL39-R40)
* Updated Bitbucket Pipelines (`bitbucket-pipelines.yml`) to use `simplinion/swagger-codegen:1.0.48` instead of `1.0.46` for both initialization and publishing steps.

**Documentation:**

* Updated the `README.md` to reflect the new Docker image version (`1.0.48`) used in the pipeline.